### PR TITLE
Add client frozen check forward

### DIFF
--- a/scripting/include/shavit_challenge.inc
+++ b/scripting/include/shavit_challenge.inc
@@ -1,0 +1,30 @@
+#if defined _shavitchallenge_included_
+#endinput
+#endif
+#define _shavitchallenge_included_
+
+/* Natives */
+
+/**
+ * Checks client's freeze status
+ *
+ * @param client    Client's id
+ * @return          True / False
+ */
+native bool shavitchallenge_IsClientFrozen(int client);
+
+public SharedPlugin:__pl_shavitchallenge =
+{
+    name = "shavit-challenge",
+    file = "shavit-challenge.smx",
+    #if defined REQUIRE_PLUGIN
+    required = 1,
+    #else
+    required = 0,
+    #endif
+};
+
+public void __pl_shavitchallenge_SetNTVOptional()
+{
+	MarkNativeAsOptional("shavitchallenge_IsClientFrozen");
+}


### PR DESCRIPTION
This adds a forward check to see if the client is frozen. This can be integrated into various anticheats if they override MOVETYPE_NONE.